### PR TITLE
Prevent storing extra fields in db

### DIFF
--- a/src/http/post-api/index.js
+++ b/src/http/post-api/index.js
@@ -54,7 +54,7 @@ let handler = async function (req) {
   // - url | string
   else {
     // store a record in our DB
-    await data.set({ table: "messages", key: req.body.email, ...req.body });
+    await data.set({ table: "messages", key: req.body.email, name: req.body.name, startup: req.body.startup, url: req.body.url });
     // ping Slack
     let message = {
       text: `name: ${req.body.name}\nemail: ${req.body.email}\nstartup: ${req.body.startup}\nurl: ${req.body.url}`,


### PR DESCRIPTION
Spreading `req.body` after validating the required parameters allows people to write all unvalidated keys to dynamo. I abused this in my application today to leave you some easter eggs if you pull up my record, but I figured that I should also put up a PR to fix this.